### PR TITLE
fixed compatibility with PHP 7.2

### DIFF
--- a/inc/plugins/image_hider.php
+++ b/inc/plugins/image_hider.php
@@ -228,13 +228,13 @@ class ImageHider {
             $equal = strpos($src, "=");
 
             $linkBegin = $equal;
-            for(; $linkBegin < sizeof($src); $linkBegin++) {
+            for(; $linkBegin < strlen($src); $linkBegin++) {
                 if(! preg_match("/\s/", substr($src, $equal, 1))) {
                     break;
                 }
             }
 
-            return substr($src, $linkBegin+1, sizeof($src)-2);
+            return substr($src, $linkBegin+1, strlen($src)-2);
         } else {
             return FALSE;
         }
@@ -255,7 +255,7 @@ class ImageHider {
             $firstQuote = strpos($src, $lastQuote);
 
             if($firstQuote) {
-                return substr($src, $firstQuote+1, sizeof($src)-2);
+                return substr($src, $firstQuote+1, strlen($src)-2);
             } else {
                 return FALSE;
             }


### PR DESCRIPTION
`sizeof()`, alias of `count()` yields a warning on invalid countable types [since PHP 7.2.0](https://secure.php.net/manual/en/function.count.php#refsect1-function.count-changelog).
These warnings result in unexpected warnings in MyBBs errorHandler that cause `run_shutdown()` [to return](https://github.com/mybb/mybb/blob/1ded732f43d095a957767508fd653e0693090f11/inc/functions.php#L145) without executing queued SQL queries stored in `$shutdown_queries`.
This fixes this bug by using `strlen()` instead of `sizeof()`.